### PR TITLE
[IDP-510] Set a blanket AnalysisLevel to latest-All

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -8,6 +8,7 @@
     <LangVersion>10</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <AnalysisLevel>latest-All</AnalysisLevel>
     <Description>Variable substitution configuration provider implementation for Microsoft.Extensions.Configuration.</Description>
   </PropertyGroup>
 


### PR DESCRIPTION
## Description of changes
We want to apply a code analysis of the latest .NET version used in the project. We can achieve this by adding an analysis level of latest-All.

## Breaking changes
None, we built the project with the AnalysisLevel and there are no new errors.

## Additional checks

Temporarily added property below for testing by building with diagnostics:
```
<ReportAnalyzer>true</ReportAnalyzer>
```
